### PR TITLE
Enable searching by game name

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function GET(req: NextRequest) {
+  const name = req.nextUrl.searchParams.get("name");
+  if (!name) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("places")
+    .select("place_id, name")
+    .ilike("name", `%${name}%`)
+    .order("last_synced_at", { ascending: false })
+    .limit(10);
+
+  if (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ data });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,27 @@ import { useState } from "react";
 import PlaceList from "@/components/PlaceList";
 
 export default function Home() {
-  const [placeId, setPlaceId] = useState("");
+  const [query, setQuery] = useState("");
   const router = useRouter();
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    try {
+      const res = await fetch(
+        `/api/search?name=${encodeURIComponent(query.trim())}`
+      );
+      const json = await res.json();
+      const first = json?.data?.[0];
+      if (first) {
+        router.push(`/place/${first.place_id}`);
+      } else {
+        window.alert("見つかりませんでした");
+      }
+    } catch (err) {
+      console.error("Search failed", err);
+      window.alert("検索に失敗しました");
+    }
+  };
 
   return (
     <main className="min-h-screen p-4">
@@ -24,16 +43,16 @@ export default function Home() {
         <div className="flex items-center shadow-md rounded-lg overflow-hidden">
           <input
             type="text"
-            value={placeId}
-            onChange={(e) => setPlaceId(e.target.value)}
-            placeholder="Place ID を入力"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="ゲーム名で検索"
             className="border px-3 py-2 focus:outline-none flex-1 rounded-none focus:ring-2 focus:ring-yellow-400"
           />
           <button
-            onClick={() => router.push(`/place/${placeId}`)}
+            onClick={handleSearch}
             className="bg-yellow-400 text-black font-semibold px-4 py-2 rounded-none hover:bg-yellow-500 transition-colors"
           >
-            開く
+            検索
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `/api/search` endpoint to look up places by game name
- update the home page search box to query by name instead of place ID

## Testing
- `npm run lint` *(fails: next not found)*