### PR TITLE
Fix missing PageProps type

### DIFF
--- a/src/app/review/[id]/page.tsx
+++ b/src/app/review/[id]/page.tsx
@@ -1,6 +1,10 @@
 // src/app/review/[id]/page.tsx
 import ReviewPage from "@/components/ReviewPage";
-import type { PageProps } from "next";
+
+interface PageProps<T extends Record<string, string | string[] | undefined> = {}> {
+  params: T;
+  searchParams?: Record<string, string | string[] | undefined>;
+}
 
 async function getPlaceInfo(placeId: number) {
   const uRes = await fetch(


### PR DESCRIPTION
## Summary
- remove invalid `PageProps` import and inline the interface

## Testing
- `npm install` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*