### PR TITLE
Fix ESLint build error

### DIFF
--- a/src/app/review/[id]/page.tsx
+++ b/src/app/review/[id]/page.tsx
@@ -1,9 +1,11 @@
 // src/app/review/[id]/page.tsx
 import ReviewPage from "@/components/ReviewPage";
 
-interface PageProps<T extends Record<string, string | string[] | undefined> = {}> {
+type RouteParams = Record<string, string | string[] | undefined>;
+
+interface PageProps<T extends RouteParams = RouteParams> {
   params: T;
-  searchParams?: Record<string, string | string[] | undefined>;
+  searchParams?: RouteParams;
 }
 
 async function getPlaceInfo(placeId: number) {


### PR DESCRIPTION
## Summary
- fix ESLint build error in review page by replacing `{}` default with a `RouteParams` record type

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*