### PR TITLE
Add visit/favorite counts to popular page

### DIFF
--- a/src/app/api/popular/route.ts
+++ b/src/app/api/popular/route.ts
@@ -47,13 +47,25 @@ export async function GET() {
   const top = scored.slice(0, 30);
 
   // フロントで利用していた列のみ返却
-  const data = top.map(({ place_id, name, creator_name, thumbnail_url, price }) => ({
-    place_id,
-    name,
-    creator_name,
-    thumbnail_url,
-    price,
-  }));
+  const data = top.map(
+    ({
+      place_id,
+      name,
+      creator_name,
+      thumbnail_url,
+      price,
+      visit_count,
+      favorite_count,
+    }) => ({
+      place_id,
+      name,
+      creator_name,
+      thumbnail_url,
+      price,
+      visit_count,
+      favorite_count,
+    })
+  );
 
   return NextResponse.json({ data });
 }


### PR DESCRIPTION
## Summary
- expose visit_count and favorite_count in `/api/popular`
- show visits, favorites and rating stars on the popular places page

## Testing
- `npm run lint` *(fails: next not found)*