### PR TITLE
Refine play button layout on review page

### DIFF
--- a/src/app/place/[id]/page.tsx
+++ b/src/app/place/[id]/page.tsx
@@ -70,6 +70,14 @@ export default function PlacePage() {
             alt={game.name}
             className="mt-2 w-full rounded-lg"
           />
+          <a
+            href={`https://www.roblox.com/games/${placeId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-block bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-2 rounded-md transition-colors"
+          >
+            プレイする
+          </a>
         </div>
       )}
       <div className="mb-4">

--- a/src/components/ReviewPage.tsx
+++ b/src/components/ReviewPage.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";          // ★ 追加
-import RatingStars from "./RatingStars";
 
 export type ReviewPageProps = {
   placeId: number;
@@ -14,14 +12,7 @@ export type ReviewPageProps = {
   rating?: number;
 };
 
-export default function ReviewPage({
-  placeId,
-  title,
-  thumbnailUrl,
-  likeCount,
-  visitCount,
-  rating,
-}: ReviewPageProps) {
+export default function ReviewPage({ placeId }: ReviewPageProps) {
   const [comment, setComment] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -31,7 +22,7 @@ export default function ReviewPage({
   };
 
   return (
-    <main className="relative max-w-xl mx-auto p-4">
+    <main className="relative max-w-xl mx-auto p-4 pt-16">
       <Link
         href="/"
         className="absolute top-4 left-4 bg-gray-200 hover:bg-gray-300 text-sm px-2 py-1 rounded"
@@ -39,39 +30,14 @@ export default function ReviewPage({
         一覧へ戻る
       </Link>
 
-      {/* カード */}
-      <div className="mb-6 bg-white dark:bg-gray-800 p-4 rounded-xl shadow">
-        <h1 className="text-2xl font-bold mb-2">{title}</h1>
-
-        {/* ★ ここだけ変更 */}
-        <Image
-          src={thumbnailUrl}
-          alt={title}
-          width={768}          // 実際サイズを指定
-          height={432}
-          className="w-full rounded-lg mb-2 object-cover"
-          priority            // LCP 改善
-        />
-
-        <div className="flex flex-wrap gap-4 text-sm text-gray-600 dark:text-gray-400">
-          <span>👍 {likeCount}</span>
-          <span>▶️ {visitCount}</span>
-          {rating !== undefined && (
-            <span className="flex items-center">
-              <RatingStars rating={rating} />
-            </span>
-          )}
-        </div>
-
-        <a
-          href={`https://www.roblox.com/games/${placeId}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-4 inline-block bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-2 rounded-md transition-colors"
-        >
-          プレイする
-        </a>
-      </div>
+      <a
+        href={`https://www.roblox.com/games/${placeId}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mb-6 block bg-green-500 hover:bg-green-600 text-white font-semibold px-4 py-2 rounded-md transition-colors text-center"
+      >
+        プレイする
+      </a>
 
       {/* レビュー投稿 */}
       <form onSubmit={handleSubmit} className="pt-4">


### PR DESCRIPTION
## Summary
- simplify the review page layout by removing the card
- show only the **プレイする** button with top padding so it doesn't overlap the back link

## Testing
- `npm run lint` *(fails: next not found)*