### PR TITLE
Add responsive global navbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,8 +26,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased pt-16`}
       >
+        <Navbar />
         {children}
       </body>
     </html>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/", label: "ホーム" },
+  { href: "/popular", label: "人気プレイス" },
+  { href: "/review", label: "レビューを書く" },
+  { href: "/mypage", label: "マイページ" },
+];
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <header className="fixed top-0 inset-x-0 z-50 bg-white dark:bg-gray-800 shadow">
+      <nav className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-16 items-center justify-between">
+          <Link href="/" className="flex items-center text-xl font-bold">
+            <span className="text-yellow-400 text-2xl mr-1">★</span>
+            <span>STAR REPO</span>
+          </Link>
+          <div className="hidden md:flex space-x-6">
+            {links.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={
+                  (isActive(href)
+                    ? "font-bold text-yellow-600"
+                    : "text-gray-700 dark:text-gray-200") +
+                  " hover:text-yellow-500 transition-colors"
+                }
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+          <button
+            onClick={() => setOpen(!open)}
+            className="md:hidden p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            <span className="sr-only">Toggle menu</span>
+            <svg
+              className="h-6 w-6"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              {open ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                />
+              )}
+            </svg>
+          </button>
+        </div>
+        {open && (
+          <div className="md:hidden pb-3 pt-2 space-y-1">
+            {links.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                onClick={() => setOpen(false)}
+                className={
+                  (isActive(href)
+                    ? "font-bold text-yellow-600"
+                    : "text-gray-700 dark:text-gray-200") +
+                  " block px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700"
+                }
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,12 @@
+import type { AppProps } from "next/app";
+import Navbar from "@/components/Navbar";
+import "../app/globals.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Navbar />
+      <Component {...pageProps} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- implement Navbar component with active links and mobile menu
- mount Navbar from root layout for all pages
- include Navbar in pages router via `_app.tsx` as well

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a5c37776883289e07bae4902351ea