### PR TITLE
Handle missing auth cookies

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -20,7 +20,15 @@ export default function MyPage() {
         // but the state expects `string | null`.
         setUserEmail(data.user.email ?? null);
       } else {
-        router.replace("/login");
+        // Cookie appears enabled but no user was returned.
+        // Inform the user before navigating away so they can adjust settings.
+        if (navigator.cookieEnabled) {
+          setMessage(
+            "ログイン情報を取得できませんでした。Cookie の設定を確認してください。"
+          );
+        } else {
+          router.replace("/login");
+        }
       }
     });
   }, [router]);


### PR DESCRIPTION
## Summary
- better message when cookies are enabled but no user is returned

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683b27394ecc8328b1cebf0ff57cd279