### PR TITLE
Fix OAuth callback to read auth code

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
+export default function AuthCallbackPage() {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const exchange = async () => {
+      try {
+        const code = new URLSearchParams(window.location.search).get("code");
+        if (!code) {
+          setError("認証コードが見つかりません");
+          return;
+        }
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          console.error("exchangeCodeForSession error", error);
+          alert("ログインに失敗しました");
+          setError("認証に失敗しました");
+          return;
+        }
+        location.replace("/");
+      } catch (err) {
+        console.error("exchangeCodeForSession error", err);
+        alert("ログインに失敗しました");
+        setError("認証に失敗しました");
+      }
+    };
+    exchange();
+  }, []);
+
+  if (error) {
+    return (
+      <main className="min-h-screen flex items-center justify-center p-4">
+        <p className="text-red-600">{error}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-4">
+      <p>Signing in…</p>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,13 +1,23 @@
 "use client";
 
+import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 
 export default function LoginPage() {
+  const [loading, setLoading] = useState(false);
+
   const handleLogin = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: { redirectTo: `${location.origin}/mypage` },
-    });
+    setLoading(true);
+    try {
+      await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: { redirectTo: `${window.location.origin}/auth/callback` },
+      });
+    } catch (error) {
+      console.error("signInWithOAuth error", error);
+      alert("Googleログインに失敗しました");
+      setLoading(false);
+    }
   };
 
   return (
@@ -15,9 +25,10 @@ export default function LoginPage() {
       <h1 className="text-2xl font-bold mb-4">ログイン</h1>
       <button
         onClick={handleLogin}
-        className="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700"
+        disabled={loading}
+        className="bg-blue-600 text-white px-6 py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
       >
-        Googleでログイン
+        {loading ? "Signing in…" : "Googleでログイン"}
       </button>
     </main>
   );


### PR DESCRIPTION
## Summary
- parse `code` parameter on the OAuth callback and pass it to `exchangeCodeForSession`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_683b3b41cc0483288a9d882baa68bf6c