### PR TITLE
Fix OAuth PKCE flow

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -9,12 +9,7 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const exchange = async () => {
       try {
-        const code = new URLSearchParams(window.location.search).get("code");
-        if (!code) {
-          setError("認証コードが見つかりません");
-          return;
-        }
-        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        const { error } = await supabase.auth.exchangeCodeForSession();
         if (error) {
           console.error("exchangeCodeForSession error", error);
           alert("ログインに失敗しました");

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,7 +11,10 @@ export default function LoginPage() {
     try {
       await supabase.auth.signInWithOAuth({
         provider: "google",
-        options: { redirectTo: `${window.location.origin}/auth/callback` },
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+        flowType: "pkce",
       });
     } catch (error) {
       console.error("signInWithOAuth error", error);


### PR DESCRIPTION
## Summary
- update Google sign-in to specify PKCE flow at the root

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683b4064765c83288de7e69033140dfd