### PR TITLE
Fix OAuth PKCE flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "starrepo",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/supabase-js": "^2.49.4",
+        "@supabase/supabase-js": "^2.53.1",
         "dotenv": "^16.5.0",
         "next": "15.3.2",
         "react": "^19.0.0",
@@ -1017,8 +1017,8 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.4.tgz",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.53.1.tgz",
       "integrity": "sha512-jUF0uRUmS8BKt37t01qaZ88H9yV1mbGYnqLeuFWLcdV+x1P4fl0yP9DGtaEhFPZcwSom7u16GkLEH9QJZOqOkw==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.49.4",
+    "@supabase/supabase-js": "^2.53.1",
     "dotenv": "^16.5.0",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -9,12 +9,7 @@ export default function AuthCallbackPage() {
   useEffect(() => {
     const exchange = async () => {
       try {
-        const code = new URLSearchParams(window.location.search).get("code");
-        if (!code) {
-          setError("認証コードが見つかりません");
-          return;
-        }
-        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        const { error } = await supabase.auth.exchangeCodeForSession();
         if (error) {
           console.error("exchangeCodeForSession error", error);
           alert("ログインに失敗しました");

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,7 +11,10 @@ export default function LoginPage() {
     try {
       await supabase.auth.signInWithOAuth({
         provider: "google",
-        options: { redirectTo: `${window.location.origin}/auth/callback` },
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+          flowType: "pkce",
+        },
       });
     } catch (error) {
       console.error("signInWithOAuth error", error);


### PR DESCRIPTION
## Summary
- bump `@supabase/supabase-js` to a newer version
- keep the PKCE option when signing in via Google
- use `exchangeCodeForSession()` without manually extracting the code

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*


------
https://chatgpt.com/codex/tasks/task_b_683b4064765c83288de7e69033140dfd