### PR TITLE
Add logging for PKCE debug

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -6,35 +6,38 @@ import { supabase } from "@/lib/supabase";
 export default function AuthCallbackPage() {
   useEffect(() => {
     (async () => {
-      // ① クエリ文字列から code を取得
-      const code = new URLSearchParams(window.location.search).get("code");
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get("code");
+      const state = params.get("state");
+
+      // ★ デバッグ: URL と localStorage を確認
+      console.log("★ URL code/state", { code, state });
+      console.log("★ localStorage keys", Object.keys(localStorage));
+      console.log(
+        "★ code_verifier",
+        localStorage.getItem("supabase.auth.code_verifier")
+      );
+
       if (!code) {
-        alert("認証コード(code)が URL に見つかりません");
-        console.error("callback URL", window.location.href);
+        alert("認可コード(code)が見つかりません");
         return;
       }
 
       try {
-        // ② 認可コードを Supabase へ渡してセッション化
         const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-
-        // ③ デバッグログ出力
         console.log("★ exchange result", { data, error });
 
         if (error) {
-          console.error("exchangeCodeForSession error", error);
           alert(`ログイン失敗: ${error.message}`);
           return;
         }
-
-        // ④ 成功したらトップへ
         window.location.replace("/");
       } catch (e) {
         console.error("unexpected error", e);
-        alert("ログイン処理で予期せぬエラーが発生しました");
+        alert("予期せぬエラーが発生しました");
       }
     })();
-  }, []); // ← 必ず依存配列を空に
+  }, []);
 
   return <p style={{ textAlign: "center" }}>Signing&nbsp;in…</p>;
 }


### PR DESCRIPTION
## Summary
- add detailed debug logging in auth callback

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bbeaecc808328851d2f1c27013c23