### PR TITLE
Rewrite PKCE callback

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,34 +3,47 @@
 import { useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 
-export default function AuthCallbackPage() {
+export default function Callback() {
   useEffect(() => {
     (async () => {
       const params = new URLSearchParams(window.location.search);
-      const code = params.get("code");
-      const state = params.get("state");
+      const authCode = params.get("code");
 
-      // ★ デバッグ: URL と localStorage を確認
-      console.log("★ URL code/state", { code, state });
-      console.log("★ localStorage keys", Object.keys(localStorage));
-      console.log(
-        "★ code_verifier",
-        localStorage.getItem("supabase.auth.code_verifier")
+      if (!authCode) {
+        alert("認可コード(code)が URL にありません");
+        console.error("callback URL", window.location.href);
+        return;
+      }
+
+      // ① localStorage から code_verifier を探す
+      const verifierKey = Object.keys(localStorage).find((k) =>
+        k.endsWith("-auth-token-code-verifier")
       );
+      const codeVerifier = verifierKey ? localStorage.getItem(verifierKey) : null;
 
-      if (!code) {
-        alert("認可コード(code)が見つかりません");
+      console.log("★ authCode", authCode);
+      console.log("★ codeVerifier", codeVerifier);
+
+      if (!codeVerifier) {
+        alert("code_verifier が取得できませんでした");
         return;
       }
 
       try {
-        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+        // ② 認可コード＋code_verifier を Supabase に交換
+        const { data, error } = await supabase.auth.exchangeCodeForSession({
+          authCode,
+          codeVerifier,
+        });
         console.log("★ exchange result", { data, error });
 
         if (error) {
+          console.error(error);
           alert(`ログイン失敗: ${error.message}`);
           return;
         }
+
+        // ③ 成功 → トップへ
         window.location.replace("/");
       } catch (e) {
         console.error("unexpected error", e);


### PR DESCRIPTION
## Summary
- rewrite callback page to manually grab the code verifier from localStorage
- exchange auth code and verifier for a session using `exchangeCodeForSession`

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_b_683bcb05686c832893dffb90f8b01955