### PR TITLE
Fix Google sign-in with PKCE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^1.0.6",
-        "@supabase/supabase-js": "^2.49.4",
+        "@supabase/supabase-js": "^2.42.0",
         "dotenv": "^16.5.0",
         "next": "15.3.2",
         "react": "^19.0.0",
@@ -998,9 +998,8 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.49.8",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
-      "integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.42.0.tgz",
       "dependencies": {
         "@supabase/auth-js": "2.69.1",
         "@supabase/functions-js": "2.4.4",
@@ -6609,9 +6608,8 @@
       }
     },
     "@supabase/supabase-js": {
-      "version": "2.49.8",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
-      "integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.42.0.tgz",
       "requires": {
         "@supabase/auth-js": "2.69.1",
         "@supabase/functions-js": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.49.4",
+    "@supabase/supabase-js": "^2.42.0",
     "dotenv": "^16.5.0",
     "next": "15.3.2",
     "react": "^19.0.0",

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -3,38 +3,17 @@
 import { useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 
-export default function AuthCallbackPage() {
+export default function Callback() {
   useEffect(() => {
     (async () => {
-      const params = new URLSearchParams(window.location.search);
-      const code = params.get("code");
-      const state = params.get("state");
-
-      // ★ デバッグ: URL と localStorage を確認
-      console.log("★ URL code/state", { code, state });
-      console.log("★ localStorage keys", Object.keys(localStorage));
-      console.log(
-        "★ code_verifier",
-        localStorage.getItem("supabase.auth.code_verifier")
-      );
-
-      if (!code) {
-        alert("認可コード(code)が見つかりません");
-        return;
-      }
-
-      try {
-        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-        console.log("★ exchange result", { data, error });
-
-        if (error) {
-          alert(`ログイン失敗: ${error.message}`);
-          return;
-        }
-        window.location.replace("/");
-      } catch (e) {
-        console.error("unexpected error", e);
-        alert("予期せぬエラーが発生しました");
+      const { error } = await supabase.auth.getSessionFromUrl({
+        storeSession: true,
+      });
+      if (error) {
+        console.error(error);
+        alert(`ログイン失敗: ${error.message}`);
+      } else {
+        location.replace("/");
       }
     })();
   }, []);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,6 +7,7 @@ export default function Login() {
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",
+        flowType: "pkce",
         options: {
           redirectTo: `${location.origin}/auth/callback`,
         },


### PR DESCRIPTION
## Summary
- enable PKCE flow when signing in with Google
- handle OAuth callback via `getSessionFromUrl`
- use `@supabase/supabase-js` v2.42.0

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c76ce426083288dbdd1dd708f916c