### PR TITLE
Refactor shared utilities

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,12 +1,11 @@
 'use client'
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 
 export default function Callback() {
   useEffect(() => {
     (async () => {
-      const { error } = await (supabase.auth as any).getSessionFromUrl({ storeSession: true })
+      const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true })
       if (error) {
         alert(`ログイン失敗: ${error.message}`)
         return

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -1,0 +1,19 @@
+import { supabase } from "./supabase";
+
+export async function fetchReviewStats(placeId: number): Promise<{
+  average: number | null;
+  count: number;
+}> {
+  const { data: reviews } = await supabase
+    .from("reviews")
+    .select("rating")
+    .eq("place_id", placeId);
+
+  const reviewCount = reviews ? reviews.length : 0;
+  const avg =
+    reviewCount > 0
+      ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviewCount
+      : null;
+
+  return { average: avg, count: reviewCount };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,21 @@
+export function formatCount(count: number | null | undefined): string {
+  if (count == null) return "-";
+  if (count >= 10000) {
+    const val = count / 10000;
+    return `${val.toFixed(val >= 10 ? 0 : 1).replace(/\.0$/, "")}万`;
+  }
+  return count.toLocaleString();
+}
+
+export async function fetchIcon(placeId: number): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://thumbnails.roblox.com/v1/places/${placeId}/icons?size=256x256&format=Png&isCircular=false`
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.data?.[0]?.imageUrl ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- create common helpers `formatCount`, `fetchIcon` and `fetchReviewStats`
- use helpers in components
- remove `any` cast in callback page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686770528a7883288891122d5b700372